### PR TITLE
Add Social Sharing Meta

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,6 +19,8 @@
     <!-- Social Sharing-->
     <meta property="og:title" content="Check My NFT" />
     <meta property="og:description" content="Do you really know how your NFT’s assets are stored?" />
+    <meta property="og:url" content="https://checkmynft.com" />
+    <meta property="og:image" content="./images/logo.png" />
 
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.

--- a/public/index.html
+++ b/public/index.html
@@ -16,6 +16,10 @@
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
 
+    <!-- Social Sharing-->
+    <meta property="og:title" content="Check My NFT" />
+    <meta property="og:description" content="Do you really know how your NFT’s assets are stored?" />
+
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.


### PR DESCRIPTION
I have begun adding some social sharing meta data (after I realised that sharing shows 'create-react-app'). I am not sure if the image will work, and I have not tested this yet (and I don't think I can until it is deployed?)