### PR TITLE
support on-chain metadata as strong instead of erroring

### DIFF
--- a/src/components/HeroSection.js
+++ b/src/components/HeroSection.js
@@ -245,18 +245,25 @@ export default function HeroSection(props) {
       let [uriURL, uriProtocol] = await getURLFromURI(tokenURI);
 
       let uriResponse;
-      try {
-        uriResponse = await fetch(uriURL, { method: "GET" });
-      } catch (e) {
-        console.error(e);
-        setFetchError(createMainError(nftAddress));
-        // setFetchError("Could not fetch NFT URI " + tokenURI);
-        setIsLoading(false);
-        return;
-      }
+      let imgURI;
 
-      let uriInfo = await uriResponse.json();
-      let imgURI = uriInfo.image;
+      if (uriProtocol !== "On-chain") {
+        try {
+          uriResponse = await fetch(uriURL, { method: "GET" });
+        } catch (e) {
+          console.error(e);
+          setFetchError(createMainError(nftAddress));
+          // setFetchError("Could not fetch NFT URI " + tokenURI);
+          setIsLoading(false);
+          return;
+        }
+
+        let uriInfo = await uriResponse.json();
+        imgURI = uriInfo.image;
+      } else {
+        // On-chain metadata can pass the image uri directly
+        imgURI = uriURL;
+      }
 
       let [imageURIURL, protocol] = await getURLFromURI(imgURI);
 
@@ -311,11 +318,12 @@ export default function HeroSection(props) {
 
       let severity = "undefined";
       switch (uriProtocol) {
-        case "ipfs":
-          severity = "medium";
-          break;
+        case "On-chain":
         case "arweave":
           severity = "strong";
+          break;
+        case "ipfs":
+          severity = "medium";
           break;
         case "centralized":
           severity = "poor";

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,6 +5,7 @@ export const arweaveEndpoint = "https://arweave.net";
 
 const CID = require("cids");
 const arweave = Arweave.init();
+const BASE64_JSON_HEADER = "data:application/json;base64,";
 
 export const buildQuery = (ipfsHash) => `
 query {
@@ -72,6 +73,16 @@ export const getURLFromURI = async (uri) => {
     if (!uri) {
       return ["", "undefined"];
     }
+
+    if (uri.indexOf(BASE64_JSON_HEADER) === 0) {
+      debugger;
+      var base64Data = uri.replace(BASE64_JSON_HEADER, "");
+      var jsonData = JSON.parse(atob(base64Data));
+      var imageData = await getURLFromURI(jsonData.image);
+      imageData[1] = "On-chain";
+      return imageData;
+    }
+
     // if correct URI we get the protocol
     let url = new URL(uri);
     // if protocol other IPFS -- get the ipfs hash
@@ -79,6 +90,7 @@ export const getURLFromURI = async (uri) => {
       // ipfs://ipfs/Qm
 
       let ipfsHash = url.href.replace("ipfs://ipfs/", "");
+      ipfsHash = ipfsHash.replace("ipfs://", "");
 
       return [ipfsGetEndpoint + ipfsHash, "ipfs"];
     }


### PR DESCRIPTION
Some smart contracts use base64 encoded JSON metadata to protect against external dependencies.

We should support NFT projects that aim to provide value through immutable on-chain art and NFTs.

Using the [vibes.art](https://vibes.art/) contract, located at:
0x6c7C97CaFf156473F6C9836522AE6e1d6448Abe7

And looking up token 1, the result is now:
![Screen Shot 2021-10-27 at 10 27 45 PM](https://user-images.githubusercontent.com/90123963/139176260-5f9db57a-76b7-43d4-a328-4f228a5cce62.png)
